### PR TITLE
fix file name mismatch and potential warmup_steps parameter errors

### DIFF
--- a/core/classify/bloom.py
+++ b/core/classify/bloom.py
@@ -13,6 +13,7 @@ from transformers import (
     BloomForSequenceClassification,
     BitsAndBytesConfig
 )
+from safetensors.torch import load_file
 
 from peft import (
     prepare_model_for_int8_training,
@@ -109,6 +110,9 @@ class BLoomClassify(LLM):
                 checkpoint_name = os.path.join(
                     self.resume_from_checkpoint, "adapter_model.bin"
                 )  # only LoRA model - LoRA config above has to fit
+                checkpoint_name_new = os.path.join(
+                    self.resume_from_checkpoint, "adapter_model.safetensors"
+                )  # when peft >= 0.7.1, the default storage name is "adapter_model.safetensors"
                 self.resume_from_checkpoint = (
                     False  # So the trainer won't try loading its state
                 )
@@ -116,6 +120,10 @@ class BLoomClassify(LLM):
             if os.path.exists(checkpoint_name):
                 print(f"Restarting from {checkpoint_name}")
                 adapters_weights = torch.load(checkpoint_name)
+                set_peft_model_state_dict(model, adapters_weights)
+            elif os.path.exists(checkpoint_name_new):
+                print(f"Restarting from {checkpoint_name_new}")
+                adapters_weights = load_file(checkpoint_name_new)
                 set_peft_model_state_dict(model, adapters_weights)
             else:
                 print(f"Checkpoint {checkpoint_name} not found")
@@ -127,7 +135,7 @@ class BLoomClassify(LLM):
         train_args = transformers.TrainingArguments(
             per_device_train_batch_size=self.per_gpu_train_batch_size,
             gradient_accumulation_steps=self.gradient_accumulation_steps,
-            warmup_steps=warmup_steps,
+            warmup_steps=warmup_steps if warmup_steps != 1 else 2,
             num_train_epochs=self.epochs,
             learning_rate=self.learning_rate,
             fp16=self.is_fp16,

--- a/core/classify/llama.py
+++ b/core/classify/llama.py
@@ -9,6 +9,7 @@ from transformers import (
     LlamaTokenizer,
     BitsAndBytesConfig
 )
+from safetensors.torch import load_file
 
 from peft import (
     prepare_model_for_int8_training,
@@ -119,6 +120,9 @@ class LLAMAClassify(LLM):
                 checkpoint_name = os.path.join(
                     self.resume_from_checkpoint, "adapter_model.bin"
                 )  # only LoRA model - LoRA config above has to fit
+                checkpoint_name_new = os.path.join(
+                    self.resume_from_checkpoint, "adapter_model.safetensors"
+                )  # when peft >= 0.7.1, the default storage name is "adapter_model.safetensors"
                 self.resume_from_checkpoint = (
                     False  # So the trainer won't try loading its state
                 )
@@ -126,6 +130,10 @@ class LLAMAClassify(LLM):
             if os.path.exists(checkpoint_name):
                 print(f"Restarting from {checkpoint_name}")
                 adapters_weights = torch.load(checkpoint_name)
+                set_peft_model_state_dict(model, adapters_weights)
+            elif os.path.exists(checkpoint_name_new):
+                print(f"Restarting from {checkpoint_name_new}")
+                adapters_weights = load_file(checkpoint_name_new)
                 set_peft_model_state_dict(model, adapters_weights)
             else:
                 print(f"Checkpoint {checkpoint_name} not found")
@@ -137,7 +145,7 @@ class LLAMAClassify(LLM):
         train_args = transformers.TrainingArguments(
             per_device_train_batch_size=self.per_gpu_train_batch_size,
             gradient_accumulation_steps=self.gradient_accumulation_steps,
-            warmup_steps=warmup_steps,
+            warmup_steps=warmup_steps if warmup_steps != 1 else 2,
             num_train_epochs=self.epochs,
             learning_rate=self.learning_rate,
             fp16=self.is_fp16,

--- a/core/seq2seq/baichuan.py
+++ b/core/seq2seq/baichuan.py
@@ -14,6 +14,7 @@ from transformers import (
     GenerationConfig,
     BitsAndBytesConfig
 )
+from safetensors.torch import load_file
 
 from peft import (
     prepare_model_for_int8_training,
@@ -195,6 +196,9 @@ class BaichuanSeq2Seq(LLM):
                 checkpoint_name = os.path.join(
                     self.resume_from_checkpoint, "adapter_model.bin"
                 )  # only LoRA model - LoRA config above has to fit
+                checkpoint_name_new = os.path.join(
+                    self.resume_from_checkpoint, "adapter_model.safetensors"
+                )  # when peft >= 0.7.1, the default storage name is "adapter_model.safetensors"
                 self.resume_from_checkpoint = (
                     False  # So the trainer won't try loading its state
                 )
@@ -202,6 +206,10 @@ class BaichuanSeq2Seq(LLM):
             if os.path.exists(checkpoint_name):
                 print(f"Restarting from {checkpoint_name}")
                 adapters_weights = torch.load(checkpoint_name)
+                set_peft_model_state_dict(model, adapters_weights)
+            elif os.path.exists(checkpoint_name_new):
+                print(f"Restarting from {checkpoint_name_new}")
+                adapters_weights = load_file(checkpoint_name_new)
                 set_peft_model_state_dict(model, adapters_weights)
             else:
                 print(f"Checkpoint {checkpoint_name} not found")
@@ -213,7 +221,7 @@ class BaichuanSeq2Seq(LLM):
         train_args = transformers.TrainingArguments(
             per_device_train_batch_size=self.per_gpu_train_batch_size,
             gradient_accumulation_steps=self.gradient_accumulation_steps,
-            warmup_steps=warmup_steps,
+            warmup_steps=warmup_steps if warmup_steps != 1 else 2,
             num_train_epochs=self.epochs,
             learning_rate=self.learning_rate,
             fp16=self.is_fp16,

--- a/core/seq2seq/chatglm.py
+++ b/core/seq2seq/chatglm.py
@@ -19,6 +19,7 @@ from transformers import (
 )
 from transformers.modeling_utils import PreTrainedModel
 from transformers.tokenization_utils import PreTrainedTokenizer
+from safetensors.torch import load_file
 
 from peft import (
     prepare_model_for_int8_training,
@@ -341,6 +342,9 @@ class ChatGLMSeq2Seq(LLM):
                 checkpoint_name = os.path.join(
                     self.resume_from_checkpoint, "adapter_model.bin"
                 )  # only LoRA model - LoRA config above has to fit
+                checkpoint_name_new = os.path.join(
+                    self.resume_from_checkpoint, "adapter_model.safetensors"
+                )  # when peft >= 0.7.1, the default storage name is "adapter_model.safetensors"
                 self.resume_from_checkpoint = (
                     False  # So the trainer won't try loading its state
                 )
@@ -348,6 +352,10 @@ class ChatGLMSeq2Seq(LLM):
             if os.path.exists(checkpoint_name):
                 print(f"Restarting from {checkpoint_name}")
                 adapters_weights = torch.load(checkpoint_name)
+                set_peft_model_state_dict(model, adapters_weights)
+            elif os.path.exists(checkpoint_name_new):
+                print(f"Restarting from {checkpoint_name_new}")
+                adapters_weights = load_file(checkpoint_name_new)
                 set_peft_model_state_dict(model, adapters_weights)
             else:
                 print(f"Checkpoint {checkpoint_name} not found")
@@ -361,7 +369,7 @@ class ChatGLMSeq2Seq(LLM):
         train_args = transformers.TrainingArguments(
             per_device_train_batch_size=self.per_gpu_train_batch_size,
             gradient_accumulation_steps=self.gradient_accumulation_steps,
-            warmup_steps=warmup_steps,
+            warmup_steps=warmup_steps if warmup_steps != 1 else 2,
             num_train_epochs=self.epochs,
             learning_rate=self.learning_rate,
             fp16=self.is_fp16,

--- a/core/seq2seq/gemma.py
+++ b/core/seq2seq/gemma.py
@@ -14,6 +14,7 @@ from transformers import (
     GenerationConfig,
     BitsAndBytesConfig
 )
+from safetensors.torch import load_file
 
 from peft import (
     prepare_model_for_int8_training,
@@ -191,6 +192,9 @@ class GemmaSeq2Seq(LLM):
                 checkpoint_name = os.path.join(
                     self.resume_from_checkpoint, "adapter_model.bin"
                 )  # only LoRA model - LoRA config above has to fit
+                checkpoint_name_new = os.path.join(
+                    self.resume_from_checkpoint, "adapter_model.safetensors"
+                )  # when peft >= 0.7.1, the default storage name is "adapter_model.safetensors"
                 self.resume_from_checkpoint = (
                     False  # So the trainer won't try loading its state
                 )
@@ -198,6 +202,10 @@ class GemmaSeq2Seq(LLM):
             if os.path.exists(checkpoint_name):
                 print(f"Restarting from {checkpoint_name}")
                 adapters_weights = torch.load(checkpoint_name)
+                set_peft_model_state_dict(model, adapters_weights)
+            elif os.path.exists(checkpoint_name_new):
+                print(f"Restarting from {checkpoint_name_new}")
+                adapters_weights = load_file(checkpoint_name_new)
                 set_peft_model_state_dict(model, adapters_weights)
             else:
                 print(f"Checkpoint {checkpoint_name} not found")
@@ -209,7 +217,7 @@ class GemmaSeq2Seq(LLM):
         train_args = transformers.TrainingArguments(
             per_device_train_batch_size=self.per_gpu_train_batch_size,
             gradient_accumulation_steps=self.gradient_accumulation_steps,
-            warmup_steps=warmup_steps,
+            warmup_steps=warmup_steps if warmup_steps != 1 else 2,
             num_train_epochs=self.epochs,
             learning_rate=self.learning_rate,
             fp16=self.is_fp16,

--- a/core/seq2seq/llama.py
+++ b/core/seq2seq/llama.py
@@ -16,6 +16,7 @@ from transformers import (
     GenerationConfig,
     BitsAndBytesConfig
 )
+from safetensors.torch import load_file
 
 from peft import (
     prepare_model_for_int8_training,
@@ -232,6 +233,9 @@ class LLAMASeq2Seq(LLM):
                 checkpoint_name = os.path.join(
                     self.resume_from_checkpoint, "adapter_model.bin"
                 )  # only LoRA model - LoRA config above has to fit
+                checkpoint_name_new = os.path.join(
+                    self.resume_from_checkpoint, "adapter_model.safetensors"
+                )  # when peft >= 0.7.1, the default storage name is "adapter_model.safetensors"
                 self.resume_from_checkpoint = (
                     False  # So the trainer won't try loading its state
                 )
@@ -239,6 +243,10 @@ class LLAMASeq2Seq(LLM):
             if os.path.exists(checkpoint_name):
                 print(f"Restarting from {checkpoint_name}")
                 adapters_weights = torch.load(checkpoint_name)
+                set_peft_model_state_dict(model, adapters_weights)
+            elif os.path.exists(checkpoint_name_new):
+                print(f"Restarting from {checkpoint_name_new}")
+                adapters_weights = load_file(checkpoint_name_new)
                 set_peft_model_state_dict(model, adapters_weights)
             else:
                 print(f"Checkpoint {checkpoint_name} not found")
@@ -250,7 +258,7 @@ class LLAMASeq2Seq(LLM):
         train_args = transformers.TrainingArguments(
             per_device_train_batch_size=self.per_gpu_train_batch_size,
             gradient_accumulation_steps=self.gradient_accumulation_steps,
-            warmup_steps=warmup_steps,
+            warmup_steps=warmup_steps if warmup_steps != 1 else 2,
             num_train_epochs=self.epochs,
             learning_rate=self.learning_rate,
             fp16=self.is_fp16,

--- a/core/seq2seq/mixtral.py
+++ b/core/seq2seq/mixtral.py
@@ -14,6 +14,7 @@ from transformers import (
     GenerationConfig,
     BitsAndBytesConfig
 )
+from safetensors.torch import load_file
 
 from peft import (
     prepare_model_for_int8_training,
@@ -203,6 +204,9 @@ class MixtralSeq2Seq(LLM):
                 checkpoint_name = os.path.join(
                     self.resume_from_checkpoint, "adapter_model.bin"
                 )  # only LoRA model - LoRA config above has to fit
+                checkpoint_name_new = os.path.join(
+                    self.resume_from_checkpoint, "adapter_model.safetensors"
+                )  # when peft >= 0.7.1, the default storage name is "adapter_model.safetensors"
                 self.resume_from_checkpoint = (
                     False  # So the trainer won't try loading its state
                 )
@@ -210,6 +214,10 @@ class MixtralSeq2Seq(LLM):
             if os.path.exists(checkpoint_name):
                 print(f"Restarting from {checkpoint_name}")
                 adapters_weights = torch.load(checkpoint_name)
+                set_peft_model_state_dict(model, adapters_weights)
+            elif os.path.exists(checkpoint_name_new):
+                print(f"Restarting from {checkpoint_name_new}")
+                adapters_weights = load_file(checkpoint_name_new)
                 set_peft_model_state_dict(model, adapters_weights)
             else:
                 print(f"Checkpoint {checkpoint_name} not found")
@@ -221,7 +229,7 @@ class MixtralSeq2Seq(LLM):
         train_args = transformers.TrainingArguments(
             per_device_train_batch_size=self.per_gpu_train_batch_size,
             gradient_accumulation_steps=self.gradient_accumulation_steps,
-            warmup_steps=warmup_steps,
+            warmup_steps=warmup_steps if warmup_steps != 1 else 2,
             num_train_epochs=self.epochs,
             learning_rate=self.learning_rate,
             fp16=self.is_fp16,

--- a/core/seq2seq/phi.py
+++ b/core/seq2seq/phi.py
@@ -14,6 +14,7 @@ from transformers import (
     GenerationConfig,
     BitsAndBytesConfig
 )
+from safetensors.torch import load_file
 
 from peft import (
     prepare_model_for_int8_training,
@@ -203,6 +204,9 @@ class PhiSeq2Seq(LLM):
                 checkpoint_name = os.path.join(
                     self.resume_from_checkpoint, "adapter_model.bin"
                 )  # only LoRA model - LoRA config above has to fit
+                checkpoint_name_new = os.path.join(
+                    self.resume_from_checkpoint, "adapter_model.safetensors"
+                )  # when peft >= 0.7.1, the default storage name is "adapter_model.safetensors"
                 self.resume_from_checkpoint = (
                     False  # So the trainer won't try loading its state
                 )
@@ -210,6 +214,10 @@ class PhiSeq2Seq(LLM):
             if os.path.exists(checkpoint_name):
                 print(f"Restarting from {checkpoint_name}")
                 adapters_weights = torch.load(checkpoint_name)
+                set_peft_model_state_dict(model, adapters_weights)
+            elif os.path.exists(checkpoint_name_new):
+                print(f"Restarting from {checkpoint_name_new}")
+                adapters_weights = load_file(checkpoint_name_new)
                 set_peft_model_state_dict(model, adapters_weights)
             else:
                 print(f"Checkpoint {checkpoint_name} not found")
@@ -221,7 +229,7 @@ class PhiSeq2Seq(LLM):
         train_args = transformers.TrainingArguments(
             per_device_train_batch_size=self.per_gpu_train_batch_size,
             gradient_accumulation_steps=self.gradient_accumulation_steps,
-            warmup_steps=warmup_steps,
+            warmup_steps=warmup_steps if warmup_steps != 1 else 2,
             num_train_epochs=self.epochs,
             learning_rate=self.learning_rate,
             fp16=self.is_fp16,

--- a/core/seq2seq/qwen.py
+++ b/core/seq2seq/qwen.py
@@ -14,6 +14,7 @@ from transformers import (
     GenerationConfig,
     BitsAndBytesConfig
 )
+from safetensors.torch import load_file
 
 from peft import (
     prepare_model_for_int8_training,
@@ -199,6 +200,9 @@ class QwenSeq2Seq(LLM):
                 checkpoint_name = os.path.join(
                     self.resume_from_checkpoint, "adapter_model.bin"
                 )  # only LoRA model - LoRA config above has to fit
+                checkpoint_name_new = os.path.join(
+                    self.resume_from_checkpoint, "adapter_model.safetensors"
+                )  # when peft >= 0.7.1, the default storage name is "adapter_model.safetensors"
                 self.resume_from_checkpoint = (
                     False  # So the trainer won't try loading its state
                 )
@@ -206,6 +210,10 @@ class QwenSeq2Seq(LLM):
             if os.path.exists(checkpoint_name):
                 print(f"Restarting from {checkpoint_name}")
                 adapters_weights = torch.load(checkpoint_name)
+                set_peft_model_state_dict(model, adapters_weights)
+            elif os.path.exists(checkpoint_name_new):
+                print(f"Restarting from {checkpoint_name_new}")
+                adapters_weights = load_file(checkpoint_name_new)
                 set_peft_model_state_dict(model, adapters_weights)
             else:
                 print(f"Checkpoint {checkpoint_name} not found")
@@ -217,7 +225,7 @@ class QwenSeq2Seq(LLM):
         train_args = transformers.TrainingArguments(
             per_device_train_batch_size=self.per_gpu_train_batch_size,
             gradient_accumulation_steps=self.gradient_accumulation_steps,
-            warmup_steps=warmup_steps,
+            warmup_steps=warmup_steps if warmup_steps != 1 else 2,
             num_train_epochs=self.epochs,
             learning_rate=self.learning_rate,
             fp16=self.is_fp16,


### PR DESCRIPTION
- Fix mismatch of default model checkpoint save names in higher versions (>= 0.7.1) of peft.
- Fix potential error where warmup_steps parameter could be 1 (raise ValueError: warmup_steps must be either 0 or > 1). Increase warmup_steps to **2** when it is equal to 1, considering that warmup_steps normally takes a value of 10% of total_steps.